### PR TITLE
Fix issue of ReadingLine div added many times

### DIFF
--- a/reading-line.js
+++ b/reading-line.js
@@ -43,7 +43,11 @@ var ReadingLine = {
     enable: function () {
         if (this.active) return;
 
-        document.body.appendChild(this.div);
+        var div = document.getElementById("ReadingLine");
+        if (div === null) {
+          document.body.appendChild(this.div);
+        }
+
         document.addEventListener("mousedown", this.mouseMove);
         document.addEventListener("mouseup", this.mouseMove);
         document.addEventListener("mousemove", this.mouseMove);


### PR DESCRIPTION
Hope you don't mind me opening a PR here. 

After the recent update to 0.0.3, sometimes the ReadingLine div is added many times. (screenshot below)

I'm not sure exactly how to reproduce the issue. But it is likely to happen when I come back to the browser window after leaving it for a while.

This PR is not a fix for the root cause, but it should prevent the div from being added multiple times.

![スクリーンショット 2022-06-15 170615](https://user-images.githubusercontent.com/25644062/173784227-87139e29-4964-4922-a5dc-d67e051aff84.png)